### PR TITLE
fix: resolve semantic conflicts from the browser-wasm merge

### DIFF
--- a/crates/cve/src/sources/snapshot.rs
+++ b/crates/cve/src/sources/snapshot.rs
@@ -11,6 +11,7 @@
 //! falls back to the public sources, so a missing/garbage snapshot is a no-op.
 
 use std::collections::BTreeMap;
+#[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -37,15 +38,25 @@ pub struct Snapshot {
 }
 
 /// Path of the on-disk snapshot: `<cache-dir>/achilles/vdb-snapshot.json`
-/// (beside the per-lookup cache the live sources use).
+/// (beside the per-lookup cache the live sources use). Absent on the web
+/// build, which has no cache dir — see the wasm `load` below.
+#[cfg(not(target_arch = "wasm32"))]
 fn snapshot_path() -> Option<PathBuf> {
     Some(dirs::cache_dir()?.join("achilles").join("vdb-snapshot.json"))
 }
 
 /// Load the snapshot from disk, or `None` if it's absent/unreadable/garbage.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn load() -> Option<Snapshot> {
     let bytes = std::fs::read(snapshot_path()?).ok()?;
     serde_json::from_slice(&bytes).ok()
+}
+
+/// The browser build has no on-disk snapshot; lookups fall through to the
+/// public sources (backed by the wasm EUVD shard store where loaded).
+#[cfg(target_arch = "wasm32")]
+pub fn load() -> Option<Snapshot> {
+    None
 }
 
 impl Snapshot {

--- a/crates/detect/src/strings.rs
+++ b/crates/detect/src/strings.rs
@@ -70,7 +70,7 @@ pub fn scan_tauri_version(binary_path: &Path) -> std::io::Result<Option<String>>
 
 /// Scan a binary for the Deno runtime version in its `Deno/x.y.z` UA token.
 pub fn scan_deno_version(binary_path: &Path) -> std::io::Result<Option<String>> {
-    let mmap = open_mmap(binary_path)?;
+    let mmap = map_bytes(binary_path)?;
     Ok(find_first(&DENO_RE, &mmap))
 }
 


### PR DESCRIPTION
browser-wasm-target and snapshots-and-deno merged cleanly in git but not in rustc: scan_deno_version still called open_mmap, renamed to map_bytes by the wasm branch, and the new VDB snapshot reader used the native-only dirs dependency on every target.

Rename the call and cfg-gate the snapshot reader following the settings/cache pattern: wasm has no on-disk snapshot, so load() returns None and lookups fall through to the public sources.