### PR TITLE
Responsive mobile foundation

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -189,7 +189,7 @@
       <header>
         <h2 id="detail-name">—</h2>
         <button id="export-detail" type="button" title="Export this app's full dossier as JSON">Export</button>
-        <button id="close-detail" type="button">&times;</button>
+        <button id="close-detail" type="button" aria-label="Close details">&times;</button>
       </header>
       <div id="detail-body"></div>
     </section>

--- a/ui/index.html
+++ b/ui/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Achilles</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="manifest" href="./manifest.webmanifest" />
-  <meta name="theme-color" content="#14101a" />
+  <meta name="theme-color" content="#141018" />
   <link rel="apple-touch-icon" href="./icon-192.png" />
 </head>
 <body>

--- a/ui/main.js
+++ b/ui/main.js
@@ -193,13 +193,13 @@ function renderRow(det) {
   tr.innerHTML = `
     <td><span class="risk ${risk}">${risk}</span></td>
     <td class="name">${escapeHtml(name)}</td>
-    <td class="version">${escapeHtml(det.bundle_version ?? "")}</td>
+    <td class="version" data-label="Version">${escapeHtml(det.bundle_version ?? "")}</td>
     <td><span class="framework-tag ${escapeHtml(det.framework)}">${escapeHtml(det.framework)}</span></td>
-    <td class="version">${escapeHtml(v.electron ?? "")}</td>
-    <td class="version">${escapeHtml(v.chromium ?? "")}</td>
-    <td class="version">${escapeHtml(v.node ?? "")}</td>
-    <td class="version">${escapeHtml(v.tauri ?? "")}</td>
-    <td class="version">${escapeHtml(v.cef ?? "")}</td>
+    <td class="version" data-label="Electron">${escapeHtml(v.electron ?? "")}</td>
+    <td class="version" data-label="Chromium">${escapeHtml(v.chromium ?? "")}</td>
+    <td class="version" data-label="Node">${escapeHtml(v.node ?? "")}</td>
+    <td class="version" data-label="Tauri">${escapeHtml(v.tauri ?? "")}</td>
+    <td class="version" data-label="CEF">${escapeHtml(v.cef ?? "")}</td>
   `;
   tr.addEventListener("click", () => openDetail(det));
   return tr;

--- a/ui/main.js
+++ b/ui/main.js
@@ -2180,7 +2180,10 @@ async function exportDetail() {
 document.querySelector("#export-all").addEventListener("click", exportAll);
 document.querySelector("#export-detail").addEventListener("click", exportDetail);
 
-rescanBtn.addEventListener("click", () => {
+// Empty the table and every per-app payload attached to it. Shared by the
+// desktop Rescan button and the web build's Clear button (which the shim
+// forwards as an "achilles:clear" event).
+function clearList() {
   rows.clear();
   // Drop the per-session detail cache too — otherwise a previously-opened app
   // keeps showing its pre-rescan audit/CVE payload (e.g. an old runtime
@@ -2190,8 +2193,16 @@ rescanBtn.addEventListener("click", () => {
   detailPanel.hidden = true;
   currentDetail = null;
   stopHelperPolling();
+  seenCount = 0;
+  expectedTotal = 0;
+}
+
+rescanBtn.addEventListener("click", () => {
+  clearList();
   startScan();
 });
+
+window.addEventListener("achilles:clear", clearList);
 
 // ---------- settings dialog ----------
 const settingsBtn = document.querySelector("#settings");

--- a/ui/manifest.webmanifest
+++ b/ui/manifest.webmanifest
@@ -5,8 +5,8 @@
   "start_url": "./",
   "scope": "./",
   "display": "standalone",
-  "background_color": "#14101a",
-  "theme_color": "#14101a",
+  "background_color": "#141018",
+  "theme_color": "#141018",
   "icons": [
     { "src": "./icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any" },
     { "src": "./icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any" },

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -642,3 +642,120 @@ dialog::backdrop {
 #euvd-snapshot-settings[hidden] { display: none; }
 #euvd-snapshot-settings label { display: block; margin: 6px 0; }
 #euvd-snapshot-settings p { margin: 6px 0; }
+
+/* ==================== narrow viewports (width < 780px) ====================
+   780px is the desktop Tauri window's minWidth, so nothing in here fires in
+   the desktop app at zoom 1.0 — the browser/PWA build is the only consumer.
+   Desktop rendering stays untouched by design. */
+
+@media (width < 780px) {
+  /* Rounded desktop window chrome is meaningless in a browser tab. */
+  #app {
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  /* The title bar can't fit controls and status side by side: wrap, and give
+     the status line (scan progress, every error message, the iOS wasm notice)
+     its own full-width row at the end. */
+  #app > header {
+    flex-wrap: wrap;
+    row-gap: var(--space-2);
+    padding: calc(10px + var(--safe-top)) calc(var(--pad-panel) + var(--safe-right))
+      10px calc(var(--pad-panel) + var(--safe-left));
+  }
+  #status {
+    flex: 1 1 100%;
+    order: 10;
+    min-width: 0;
+  }
+
+  /* List ↔ detail becomes show-one-at-a-time: both panels share the single
+     grid cell, and the list keeps its scroll position while hidden behind
+     the detail takeover. */
+  main:has(#detail-panel:not([hidden])) {
+    grid-template-columns: 1fr;
+  }
+  main > #list-panel,
+  main > #detail-panel {
+    grid-area: 1 / 1;
+  }
+  main:has(#detail-panel:not([hidden])) > #list-panel {
+    visibility: hidden;
+  }
+  #list-panel {
+    overscroll-behavior: contain;
+    padding-bottom: var(--safe-bottom);
+  }
+  #detail-panel {
+    border-left: none;
+    padding-bottom: var(--safe-bottom);
+  }
+  /* Promote the × into a leading back/close control. */
+  #detail-panel header {
+    padding-left: calc(var(--pad-panel) + var(--safe-left));
+  }
+  #close-detail {
+    order: -1;
+    min-width: var(--tap);
+    min-height: var(--tap);
+    font-size: 18px;
+  }
+  #detail-panel h2 {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+  .binmeta-list ul {
+    max-height: 45dvh; /* was a desktop-sized 340px */
+  }
+}
+
+/* Touch ergonomics — keyed to the pointer, not the width, so touch-primary
+   desktops get them too. Mouse-driven desktops are unaffected. */
+@media (pointer: coarse) {
+  #app > header button,
+  #close-detail,
+  #export-detail,
+  #update-banner button,
+  #settings-form > footer button,
+  #detail-body .cve-tab {
+    min-height: var(--tap);
+    padding-top: var(--space-2);
+    padding-bottom: var(--space-2);
+  }
+  #settings-close {
+    min-width: var(--tap);
+    min-height: var(--tap);
+  }
+  /* Filter chips stay visually compact; extend their hit area invisibly. */
+  .th-filter-btn,
+  .th-clear-btn {
+    position: relative;
+    min-width: 24px;
+    min-height: 24px;
+  }
+  .th-filter-btn::after,
+  .th-clear-btn::after {
+    content: "";
+    position: absolute;
+    inset: -10px;
+  }
+  /* Disclosure rows: keep display:list-item (preserves the marker), grow the
+     tappable box instead. */
+  .binmeta-list > summary,
+  #detail-body details.advisory > summary {
+    min-height: var(--tap);
+    padding: var(--space-2) 0;
+  }
+  #apps tbody td {
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+  /* iOS Safari auto-zooms the page when focusing inputs smaller than 16px. */
+  .th-popover input,
+  .th-popover select,
+  #settings-form input,
+  #settings-form select {
+    font-size: 16px;
+  }
+}

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -145,6 +145,12 @@ html[data-host="web"] #window-controls {
   display: none;
 }
 
+/* The desktop Rescan (Spotlight re-enumeration) has no web meaning — the
+   shim-injected Open/Clear controls replace it there. */
+html[data-host="web"] #rescan {
+  display: none;
+}
+
 header h1 {
   font-size: 13px;
   font-weight: 600;
@@ -185,6 +191,13 @@ button {
 }
 
 button:disabled { opacity: 0.5; cursor: default; }
+
+/* Secondary header action: present but visually quiet. */
+.btn-quiet {
+  background: transparent;
+  border-color: var(--bg-3);
+  color: var(--fg-2);
+}
 
 :focus-visible {
   outline: 2px solid var(--accent);

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -787,6 +787,52 @@ dialog::backdrop {
   #apps tbody td:last-child {
     padding-right: 0;
   }
+
+  /* Settings: labels stack above their inputs — the max-content label column
+     otherwise squeezes inputs to nothing. Number rows ("Reassess every [n]
+     minutes") keep the input and its trailing unit on one wrappable line. */
+  #settings-form .source label.field {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+  #settings-form .source label.field:has(input[type="number"]) {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2);
+  }
+}
+
+/* Phones: the settings dialog takes the whole screen, header and actions
+   pinned while the sources scroll between them. */
+@media (width < 420px) {
+  dialog {
+    width: 100vw;
+    max-width: none;
+    height: 100dvh;
+    max-height: none;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+    padding-top: var(--safe-top);
+    padding-bottom: var(--safe-bottom);
+  }
+  #settings-form {
+    height: 100%;
+    overflow-y: auto;
+  }
+  #settings-form > header {
+    position: sticky;
+    top: 0;
+    background: var(--bg-2);
+    z-index: 1;
+  }
+  #settings-form > footer {
+    position: sticky;
+    bottom: 0;
+    background: var(--bg-2);
+    border-top: 1px solid var(--bg-3);
+  }
 }
 
 /* Touch ergonomics — keyed to the pointer, not the width, so touch-primary

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -10,7 +10,32 @@
   --warn: #ffd36b;
   --bad: #ff6b8b;
   --mono: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
+  /* spacing scale — names the paddings/gaps already in use */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --pad-panel: 14px;
+  /* type scale */
+  --text-xs: 11px;
+  --text-sm: 12px;
+  --text-base: 13px;
+  --text-lg: 14px;
+  /* minimum touch target (Apple HIG / WCAG 2.5.8) */
+  --tap: 44px;
+  /* Safe-area insets: 0 everywhere except notched mobile devices — needs
+     viewport-fit=cover in the viewport meta to be non-zero at all. */
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
 }
+
+/* Breakpoints (custom properties can't appear in @media — keep in sync):
+     narrow: width < 780px  == tauri.conf.json minWidth, so it never fires in
+                               the desktop app at zoom 1.0
+     phone:  width < 420px */
 
 * { box-sizing: border-box; }
 
@@ -34,6 +59,12 @@ body {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  /* Track the dynamic viewport on mobile (URL-bar collapse); resolves the
+     same as the 100% fallback above under desktop Tauri. */
+  height: 100dvh;
+  /* The app is a fixed frame with internal scroll panes — don't let Android
+     pull-to-refresh rubber-band the whole frame. */
+  overscroll-behavior: none;
 }
 
 #app {
@@ -80,8 +111,10 @@ header [data-tauri-drag-region] {
   color: transparent;
   transition: filter 0.1s;
 }
-#window-controls:hover button {
-  color: rgba(0, 0, 0, 0.55);
+@media (hover: hover) {
+  #window-controls:hover button {
+    color: rgba(0, 0, 0, 0.55);
+  }
 }
 #win-close {
   background: #ff5f57;
@@ -103,6 +136,13 @@ header [data-tauri-drag-region] {
 }
 #window-controls button:active {
   filter: brightness(0.85);
+}
+
+/* The traffic lights only make sense under desktop Tauri; the web shim marks
+   the document so they disappear in the browser/PWA. A future mobile shell
+   sets its own data-host and reuses this gate. */
+html[data-host="web"] #window-controls {
+  display: none;
 }
 
 header h1 {
@@ -139,10 +179,17 @@ button {
   cursor: pointer;
 }
 
-button:hover { border-color: var(--accent); }
+@media (hover: hover) {
+  button:hover { border-color: var(--accent); }
+  button:disabled:hover { border-color: transparent; }
+}
 
 button:disabled { opacity: 0.5; cursor: default; }
-button:disabled:hover { border-color: transparent; }
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 
 #update-banner {
   display: flex;
@@ -185,14 +232,19 @@ table {
 }
 
 thead th {
-  position: sticky;
-  top: 0;
   background: var(--bg-2);
   text-align: left;
   padding: 6px 10px;
   font-weight: 600;
   color: var(--fg-2);
   border-bottom: 1px solid var(--bg-3);
+}
+
+/* Stickiness is app-table-only: nested data tables in the detail pane (e.g.
+   .crypto-dests) would otherwise pin their headers inside the scrolling pane. */
+#apps thead th {
+  position: sticky;
+  top: 0;
   z-index: 1;
 }
 
@@ -216,10 +268,12 @@ thead th {
   line-height: 1;
   cursor: pointer;
 }
-.th-filter-btn:hover,
-.th-clear-btn:hover {
-  border: none;
-  color: var(--accent);
+@media (hover: hover) {
+  .th-filter-btn:hover,
+  .th-clear-btn:hover {
+    border: none;
+    color: var(--accent);
+  }
 }
 
 thead th.filtered { color: var(--accent); }
@@ -261,9 +315,13 @@ tbody td {
   padding-right: 20px;
 }
 
-tbody tr { cursor: pointer; }
-tbody tr:hover { background: var(--bg-2); }
-tbody tr.selected { background: var(--bg-3); }
+/* Row interactivity belongs to the app table only — .crypto-dests rows in the
+   detail pane are plain data, not clickable. */
+#apps tbody tr { cursor: pointer; }
+@media (hover: hover) {
+  #apps tbody tr:hover { background: var(--bg-2); }
+}
+#apps tbody tr.selected { background: var(--bg-3); }
 
 td.name {
   font-family: system-ui, sans-serif;
@@ -544,9 +602,11 @@ dialog::backdrop {
   color: var(--fg-2);
   font-family: var(--mono);
 }
-#detail-body .cve-tab:hover {
-  border-color: transparent;
-  color: var(--fg);
+@media (hover: hover) {
+  #detail-body .cve-tab:hover {
+    border-color: transparent;
+    color: var(--fg);
+  }
 }
 #detail-body .cve-tab.active {
   color: var(--accent);
@@ -563,6 +623,14 @@ dialog::backdrop {
   to { background: transparent; }
 }
 #detail-body .advisory.flash-new { animation: achilles-flash-new 2.4s ease-out; }
+
+@media (prefers-reduced-motion: reduce) {
+  #window-controls button { transition: none; }
+  #detail-body .advisory.flash-new {
+    animation: none;
+    background: color-mix(in srgb, var(--accent) 20%, transparent);
+  }
+}
 
 /* Web-only EUVD snapshot controls, nested under the EUVD source entry in the
    settings dialog and collapsed (hidden) when EUVD is unchecked. */

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -664,6 +664,11 @@ dialog::backdrop {
     padding: calc(10px + var(--safe-top)) calc(var(--pad-panel) + var(--safe-right))
       10px calc(var(--pad-panel) + var(--safe-left));
   }
+  /* The title takes its own row, so the buttons flow as one uniform
+     wrapping row beneath it instead of splitting raggedly around it. */
+  #app > header h1 {
+    flex: 1 1 100%;
+  }
   #status {
     flex: 1 1 100%;
     order: 10;

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -192,13 +192,6 @@ button {
 
 button:disabled { opacity: 0.5; cursor: default; }
 
-/* Secondary header action: present but visually quiet. */
-.btn-quiet {
-  background: transparent;
-  border-color: var(--bg-3);
-  color: var(--fg-2);
-}
-
 :focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -708,6 +708,85 @@ dialog::backdrop {
   .binmeta-list ul {
     max-height: 45dvh; /* was a desktop-sized 340px */
   }
+
+  /* The 9-column table becomes a card list. The runtime-version columns are
+     sparse, so empty cells collapse and each card shows only the versions the
+     app actually carries. Placement keys off :has() and the existing semantic
+     classes — no nth-child — so the same markup can later move into a Lit
+     template untouched. */
+  #apps,
+  #apps tbody {
+    display: block;
+  }
+  #apps tbody tr {
+    display: grid;
+    grid-template-columns: max-content 1fr max-content;
+    gap: 2px 10px;
+    align-items: center;
+    padding: var(--space-3) calc(var(--pad-panel) + var(--safe-right))
+      var(--space-3) calc(var(--pad-panel) + var(--safe-left));
+    border-bottom: 1px solid var(--bg-2);
+  }
+  #apps tbody td {
+    display: block;
+    padding: 0;
+    border: 0;
+    min-width: 0;
+  }
+  #apps tbody td:empty {
+    display: none;
+  }
+  #apps tbody td:has(.risk) {
+    grid-area: 1 / 1;
+  }
+  #apps tbody td.name {
+    grid-area: 1 / 2;
+    font-size: var(--text-lg);
+    overflow-wrap: anywhere;
+  }
+  #apps tbody td:has(.framework-tag) {
+    grid-area: 1 / 3;
+  }
+  #apps tbody td.version {
+    grid-column: 1 / -1;
+  }
+  #apps tbody td.version[data-label]::before {
+    content: attr(data-label) ": ";
+    color: var(--fg-2);
+  }
+
+  /* The header row becomes a sticky bar of filter chips; the per-column
+     popovers (position:fixed, viewport-clamped in main.js) work unchanged. */
+  #apps thead {
+    display: block;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: var(--bg-2);
+    padding: var(--space-2) calc(var(--space-2) + var(--safe-right))
+      var(--space-2) calc(var(--space-2) + var(--safe-left));
+    border-bottom: 1px solid var(--bg-3);
+  }
+  #apps thead tr {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-1);
+  }
+  #apps thead th {
+    position: static;
+    display: inline-flex;
+    padding: 6px 10px;
+    border: 1px solid var(--bg-3);
+    border-radius: 999px;
+  }
+  /* Neutralize the desktop scrollbar inset (cards/chips manage their own
+     edge padding). */
+  #apps thead th:last-child {
+    padding-right: 10px;
+  }
+  #apps tbody td:last-child {
+    padding-right: 0;
+  }
 }
 
 /* Touch ergonomics — keyed to the pointer, not the width, so touch-primary
@@ -747,15 +826,20 @@ dialog::backdrop {
     min-height: var(--tap);
     padding: var(--space-2) 0;
   }
-  #apps tbody td {
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
   /* iOS Safari auto-zooms the page when focusing inputs smaller than 16px. */
   .th-popover input,
   .th-popover select,
   #settings-form input,
   #settings-form select {
     font-size: 16px;
+  }
+}
+
+/* Wide touch screens still show the real table — give its rows a tap-friendly
+   height there. (Below 780px the card layout brings its own padding.) */
+@media (pointer: coarse) and (width >= 780px) {
+  #apps tbody td {
+    padding-top: 10px;
+    padding-bottom: 10px;
   }
 }

--- a/ui/sw.js
+++ b/ui/sw.js
@@ -6,7 +6,7 @@
 // stable filenames), so we always prefer a fresh copy when online and fall back
 // to the cache only when offline. The app shell is pre-cached on install so the
 // very first offline load still works. Bump CACHE to evict everything.
-const CACHE = "achilles-browser-v2";
+const CACHE = "achilles-browser-v3";
 const SHELL = [
   "./",
   "./index.html",
@@ -17,6 +17,13 @@ const SHELL = [
   "./manifest.webmanifest",
   "./icon-192.png",
   "./icon-512.png",
+  "./icon-maskable.png",
+  // The wasm analysis core (~2.6 MB) is part of the shell: without it a
+  // first-ever offline launch renders a UI that can't analyze anything.
+  // addAll is atomic, so serving ui/ without a prior build-web.sh simply
+  // skips SW install — the app itself still works online.
+  "./pkg/achilles_wasm.js",
+  "./pkg/achilles_wasm_bg.wasm",
 ];
 
 self.addEventListener("install", (event) => {

--- a/ui/tauri-shim.js
+++ b/ui/tauri-shim.js
@@ -504,25 +504,15 @@ function installWebShim() {
     setStatus(`${done}${problems.join("; ")}${hint}`);
   }
 
-  // `scan` is fired both on boot (no user gesture) and from the Rescan button
-  // (a gesture). `showDirectoryPicker` needs transient activation, so only open
-  // it when a gesture is active; otherwise just prompt.
+  // `scan` fires on boot (and from the desktop Rescan, which is hidden on the
+  // web) — never with the transient activation the pickers need — so it only
+  // sets the ingest hint. Actual ingestion runs through the injected header
+  // controls and the dropzone.
   async function webScan() {
-    if (window.showDirectoryPicker && navigator.userActivation?.isActive) {
-      try {
-        await scanViaDirectoryPicker();
-      } catch (e) {
-        if (e?.name !== "AbortError") {
-          console.warn("folder scan failed", e);
-          setStatus(`scan failed: ${e}`);
-        }
-      }
-      return;
-    }
     setStatus(
       window.showDirectoryPicker
-        ? `Click ‘Scan folder’ to choose a directory, or ‘Select file’ for ${SUPPORTED_FILES}.`
-        : `Click ‘Select file’ to choose ${SUPPORTED_FILES} — your browser has no folder picker.`,
+        ? `Click ‘Open’ to pick a folder (e.g. /Applications), or ‘archive…’ for ${SUPPORTED_FILES}.`
+        : `Click ‘Open’ to choose ${SUPPORTED_FILES}.`,
     );
   }
 
@@ -683,22 +673,9 @@ function installWebShim() {
   function injectControls() {
     const header = document.querySelector("header");
     if (!header) return;
-    const anchor = document.querySelector("#rescan") ?? header.lastElementChild;
-
-    if (window.showDirectoryPicker) {
-      const scanBtn = document.createElement("button");
-      scanBtn.type = "button";
-      scanBtn.textContent = "Scan folder";
-      scanBtn.title =
-        "Pick a folder: /Applications scans every .app in it, any other folder " +
-        "(a Windows install directory, a Linux app tree, one .app) is scanned as a single app";
-      scanBtn.addEventListener("click", () => {
-        void scanViaDirectoryPicker().catch((e) => {
-          if (e?.name !== "AbortError") setStatus(`scan failed: ${e}`);
-        });
-      });
-      header.insertBefore(scanBtn, anchor);
-    }
+    // Ingestion is the browser build's primary action: its controls go in
+    // front of the shared Export/Settings buttons.
+    const anchor = document.querySelector("#export-all") ?? header.lastElementChild;
 
     // `<select>` gets no styling from styles.css (the desktop build has none),
     // so match the header buttons here.
@@ -732,7 +709,6 @@ function installWebShim() {
     platformSelect.addEventListener("change", () => {
       forcedPlatform = platformSelect.value;
     });
-    header.insertBefore(platformSelect, anchor);
 
     const fileInput = document.createElement("input");
     fileInput.type = "file";
@@ -746,12 +722,57 @@ function installWebShim() {
       if (file) void scanViaFile(file);
       fileInput.value = "";
     });
-    const selectBtn = document.createElement("button");
-    selectBtn.type = "button";
-    selectBtn.textContent = "Select file";
-    selectBtn.title = `Select ${SUPPORTED_FILES}`;
-    selectBtn.addEventListener("click", () => fileInput.click());
-    header.insertBefore(selectBtn, anchor);
+
+    // One capability-aware "Open": the directory picker where the browser has
+    // one (a `.app` bundle is itself a directory, so that covers single apps
+    // too), the plain file picker everywhere else.
+    const openBtn = document.createElement("button");
+    openBtn.type = "button";
+    openBtn.textContent = "Open";
+    if (window.showDirectoryPicker) {
+      openBtn.title =
+        "Pick a folder: /Applications scans every .app in it, any other folder " +
+        "(a Windows install directory, a Linux app tree, one .app) is scanned as a single app";
+      openBtn.addEventListener("click", () => {
+        void scanViaDirectoryPicker().catch((e) => {
+          if (e?.name !== "AbortError") setStatus(`scan failed: ${e}`);
+        });
+      });
+    } else {
+      openBtn.title = `Choose ${SUPPORTED_FILES}`;
+      openBtn.addEventListener("click", () => fileInput.click());
+    }
+    header.insertBefore(openBtn, anchor);
+
+    // A directory picker can't select files, so browsers that got one keep a
+    // quiet secondary control for single-file uploads.
+    if (window.showDirectoryPicker) {
+      const archiveBtn = document.createElement("button");
+      archiveBtn.type = "button";
+      archiveBtn.className = "btn-quiet";
+      archiveBtn.textContent = "archive…";
+      archiveBtn.title = `Select ${SUPPORTED_FILES}`;
+      archiveBtn.addEventListener("click", () => fileInput.click());
+      header.insertBefore(archiveBtn, anchor);
+    }
+
+    // Which OS layout uploads are read as; applies to folders and files alike.
+    header.insertBefore(platformSelect, anchor);
+
+    // Clear: main.js owns the list state and empties it on this event; the
+    // analysis caches here go with it so a re-opened app re-analyses fresh.
+    const clearBtn = document.createElement("button");
+    clearBtn.type = "button";
+    clearBtn.textContent = "Clear";
+    clearBtn.title = "Empty the list and drop the analysis results";
+    clearBtn.addEventListener("click", () => {
+      window.dispatchEvent(new CustomEvent("achilles:clear"));
+      analyzed.clear();
+      rootToPath.clear();
+      void webScan(); // reset the status line to the ingest hint
+    });
+    header.insertBefore(clearBtn, anchor);
+
     header.appendChild(fileInput);
   }
 
@@ -922,7 +943,7 @@ function installWebShim() {
       show(true);
       setStatus(
         "Couldn't read the dropped folder — Safari can't reliably read dropped " +
-        "directories. Zip the app folder and drop (or ‘Select file’) the .zip instead.",
+        "directories. Zip the app folder and drop (or ‘Open’) the .zip instead.",
       );
       setTimeout(hide, 4000);
       return;

--- a/ui/tauri-shim.js
+++ b/ui/tauri-shim.js
@@ -19,6 +19,10 @@ if (!window.__TAURI_INTERNALS__ && !window.__TAURI__) {
 }
 
 function installWebShim() {
+  // Mark the host so the stylesheet can gate desktop-only chrome (the
+  // traffic-light window controls) off the web build.
+  document.documentElement.dataset.host = "web";
+
   // `wasm` is filled in once the module loads; `ready` gates anything that
   // needs it. main.js can destructure `window.__TAURI__` immediately because
   // we assign it synchronously at the end of this function.

--- a/ui/tauri-shim.js
+++ b/ui/tauri-shim.js
@@ -511,7 +511,7 @@ function installWebShim() {
   async function webScan() {
     setStatus(
       window.showDirectoryPicker
-        ? `Click ‘Open’ to pick a folder (e.g. /Applications), or ‘archive…’ for ${SUPPORTED_FILES}.`
+        ? `Click ‘Open folder’ to pick one (e.g. /Applications), or ‘Open file…’ for ${SUPPORTED_FILES}.`
         : `Click ‘Open’ to choose ${SUPPORTED_FILES}.`,
     );
   }
@@ -723,13 +723,15 @@ function installWebShim() {
       fileInput.value = "";
     });
 
-    // One capability-aware "Open": the directory picker where the browser has
+    // Capability-aware ingestion: the directory picker where the browser has
     // one (a `.app` bundle is itself a directory, so that covers single apps
-    // too), the plain file picker everywhere else.
+    // too), the plain file picker everywhere else. A directory picker can't
+    // select files, so browsers that got one carry a second button for
+    // zipped .apps / bare asars — the labels explain the split themselves.
     const openBtn = document.createElement("button");
     openBtn.type = "button";
-    openBtn.textContent = "Open";
     if (window.showDirectoryPicker) {
+      openBtn.textContent = "Open folder";
       openBtn.title =
         "Pick a folder: /Applications scans every .app in it, any other folder " +
         "(a Windows install directory, a Linux app tree, one .app) is scanned as a single app";
@@ -739,18 +741,18 @@ function installWebShim() {
         });
       });
     } else {
+      openBtn.textContent = "Open";
       openBtn.title = `Choose ${SUPPORTED_FILES}`;
       openBtn.addEventListener("click", () => fileInput.click());
     }
     header.insertBefore(openBtn, anchor);
 
     // A directory picker can't select files, so browsers that got one keep a
-    // quiet secondary control for single-file uploads.
+    // second button for single-file uploads.
     if (window.showDirectoryPicker) {
       const archiveBtn = document.createElement("button");
       archiveBtn.type = "button";
-      archiveBtn.className = "btn-quiet";
-      archiveBtn.textContent = "archive…";
+      archiveBtn.textContent = "Open file…";
       archiveBtn.title = `Select ${SUPPORTED_FILES}`;
       archiveBtn.addEventListener("click", () => fileInput.click());
       header.insertBefore(archiveBtn, anchor);


### PR DESCRIPTION
Makes the browser/PWA build usable on phones.
CSS-first on the existing vanilla codebase (Track R of the frontend roadmap); the Lit/web_modules migration is a separate track.
Desktop rendering is untouched: every layout change sits behind `@media (width < 780px)` — the desktop window's minWidth — or `(pointer: coarse)` / `(hover: hover)` guards.

One commit per milestone:

- **Foundation** — spacing/type/tap/safe-area tokens, `100dvh`, `:focus-visible`, hover and reduced-motion guards.
  The web shim sets `data-host="web"`; CSS hides the traffic-light window controls there.
  Sticky headers and row interactivity are scoped to `#apps` (the nested `.crypto-dests` table inherited both); theme-color matches `--bg`.
- **Frame** — the title bar wraps with the status line on its own row; the `1fr 420px` detail split becomes a full-screen takeover with a ≥44px close control; 16px inputs stop iOS focus auto-zoom; safe-area insets at the frame edges.
- **Cards** — below 780px the 9-column table renders as a card list: sparse runtime versions self-label via `data-label` and collapse via `td:empty`; the thead becomes a sticky filter-chip bar; the popover filter code is untouched.
- **Settings** — label-over-input below 780px; full-screen dialog with pinned header/footer below 420px.
- **PWA** — the wasm core and maskable icon join the service-worker precache (a first-ever offline launch could not analyse anything); cache v3.
- **Ingest** — `Open folder` + `Open archive…` where the browser has a directory picker (a directory picker cannot select `.zip`/`.asar` files), a single `Open` file picker elsewhere.
  `Clear` is the list-emptying half of the former Rescan handler, shared via an `achilles:clear` event; the shim drops its analysis caches with it.
  Rescan is desktop-only and hidden on the web through the `data-host` gate.