### PR TITLE
euvd: one client fetches, everything else reads the cache

### DIFF
--- a/.github/workflows/euvd-refresh.yml
+++ b/.github/workflows/euvd-refresh.yml
@@ -1,24 +1,26 @@
 name: Refresh EUVD snapshot
 
-# The browser build ships a pre-fetched EUVD snapshot as a static asset (EUVD
-# blocks browser-origin requests, so the web build can't query it live). EUVD
-# publishes continuously, so this checks hourly whether any runtime Achilles
-# tracks gained or lost advisories and, only then, re-dispatches the Pages
-# deploy — which re-fetches the authoritative data at build time. The snapshot
-# version is a content hash, so an occasional redundant rebuild is harmless
-# (clients see no change); the probe is a best-effort gate on additions.
+# The one place that talks to EUVD. The browser build ships a pre-fetched
+# snapshot as a static asset (EUVD blocks browser-origin requests, so the web
+# build can't query it live), and ENISA throttles bursts — so this workflow
+# fetches, publishes the result as the `euvd-snapshot` artifact, and dispatches
+# the Pages deploy. The deploy reads that artifact through
+# scripts/provision-euvd.sh; nothing outside this workflow contacts ENISA.
 #
-# Note: GitHub only runs `schedule` triggers from the default branch, so the
-# hourly run activates once this lands there. `workflow_dispatch` works from any
-# branch in the meantime.
+# Every six hours it probes the per-runtime totals — one cheap request each — and
+# pays for the full paginated crawl only when a total actually moved. The
+# snapshot version is a content hash, so a redundant refresh is harmless.
+#
+# Note: GitHub only runs `schedule` triggers from the default branch, and only
+# once Actions is enabled in a fork. `workflow_dispatch` works from any branch.
 
 on:
   schedule:
-    - cron: "0 0 * * *" # daily at midnight, off the top of the hour
+    - cron: "17 */6 * * *" # four times a day, off the top of the hour
   workflow_dispatch:
 
-# Least privilege: this only dispatches the deploy workflow. It never writes
-# content, commits, or deploys a page itself.
+# Least privilege: read the previous artifact, publish the new one, dispatch the
+# deploy. It never writes content, commits, or deploys a page itself.
 permissions:
   actions: write
 
@@ -27,54 +29,98 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
+  refresh:
     runs-on: ubuntu-latest
     steps:
-      - name: Probe EUVD totals against the deployed snapshot
-        id: probe
+      - uses: actions/checkout@v7
+
+      # Cron fires every repository carrying this workflow at the same instant,
+      # and they all point at ENISA. Spread them by an offset derived from the
+      # repository name: different for every fork, identical on every run of one
+      # repository, and needing no stored state. Manual runs skip it — nobody
+      # dispatching by hand should sit through a wait.
+      - name: Stagger this repository's slot
+        if: github.event_name == 'schedule'
         run: |
           set -euo pipefail
-          api="https://euvdservices.enisa.europa.eu/api"
-          owner="${GITHUB_REPOSITORY%%/*}"
-          repo="${GITHUB_REPOSITORY##*/}"
-          base="https://${owner}.github.io/${repo}/browser/euvd"
+          offset=$((0x$(printf '%s' "$GITHUB_REPOSITORY" | sha256sum | cut -c1-4) % 1200))
+          echo "waiting ${offset}s so sibling repositories don't fetch in lockstep"
+          sleep "$offset"
 
-          # Previous per-shard counts from the deployed manifest. Absent on the
-          # very first run (no snapshot deployed yet) → refresh to seed it.
-          manifest="$(curl -fsS "$base/index.json" || true)"
-          if [ -z "$manifest" ]; then
-            echo "no deployed snapshot yet → refresh"
+      # The published artifact is the snapshot of record, so it is also the
+      # baseline: the question is whether the cache is stale, not whether the
+      # deployment is. The deployed manifest covers the window before a first
+      # artifact exists; with neither, refresh to seed one.
+      - name: Read the current snapshot's per-shard counts
+        id: baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          dir="$(mktemp -d)"
+          run="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow euvd-refresh.yml \
+            --status success --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)"
+          if [ -n "$run" ] && gh run download "$run" --repo "$GITHUB_REPOSITORY" \
+            --name euvd-snapshot --dir "$dir" >/dev/null 2>&1 && [ -s "$dir/index.json" ]; then
+            echo "baseline: the euvd-snapshot artifact from run $run"
+          else
+            base="https://${GITHUB_REPOSITORY%%/*}.github.io/${GITHUB_REPOSITORY##*/}/browser/euvd"
+            curl -fsS -o "$dir/index.json" "$base/index.json" 2>/dev/null \
+              && echo "baseline: the deployed snapshot" \
+              || echo "baseline: none"
+          fi
+          if [ -s "$dir/index.json" ]; then
+            echo "manifest=$dir/index.json" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Probe EUVD totals against that baseline
+        id: probe
+        env:
+          MANIFEST: ${{ steps.baseline.outputs.manifest }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MANIFEST:-}" ]; then
+            echo "no snapshot yet → refresh"
             echo "changed=true" >>"$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # vendor|product|slug — must match scripts/fetch-euvd.sh.
-          pairs=(
-            "Electron|Electron|electron"
-            "Tauri|Tauri|tauri"
-            "Node.js|Node.js|node"
-            "Google|Chrome|chrome"
-            "Google|Flutter|flutter"
-            "Qt|Qt|qt"
-            "nwjs|NW.js|nwjs"
-            "Apple|Safari|safari"
-            "Oracle|JDK|jdk"
-          )
+          api="https://euvdservices.enisa.europa.eu/api"
           changed=false
-          for entry in "${pairs[@]}"; do
-            IFS='|' read -r vendor product slug <<<"$entry"
+          # The runtime list lives in the fetcher; reading it from there is what
+          # keeps the two from drifting apart — that drift is how Deno ended up
+          # dispatched with no shard to answer from.
+          while IFS='|' read -r vendor product slug; do
+            [ -n "${slug:-}" ] || continue
             ev="$(jq -rn --arg s "$vendor" '$s|@uri')"
             ep="$(jq -rn --arg s "$product" '$s|@uri')"
-            total="$(curl -fsS "$api/search?vendor=$ev&product=$ep&size=1&page=0" | jq -r '.total // 0')"
-            prev="$(jq -r --arg s "$slug" '.shards[$s].count // -1' <<<"$manifest")"
+            total="$(curl -fsS --retry 3 --retry-all-errors --retry-delay 2 \
+              "$api/search?vendor=$ev&product=$ep&size=1&page=0" | jq -r '.total // 0')"
+            prev="$(jq -r --arg s "$slug" '.shards[$s].count // -1' "$MANIFEST")"
             if [ "$total" != "$prev" ]; then
               echo "$slug: live total=$total, snapshot count=$prev → stale"
               changed=true
             fi
-          done
+          done < <(./scripts/fetch-euvd.sh --list-pairs)
           echo "changed=$changed" >>"$GITHUB_OUTPUT"
 
-      - name: Dispatch the Pages deploy when the snapshot is stale
+      - name: Fetch the snapshot
+        if: steps.probe.outputs.changed == 'true'
+        run: ./scripts/fetch-euvd.sh "${{ runner.temp }}/euvd"
+
+      # What every other workflow reads. Ninety days is the maximum retention and
+      # a six-hourly refresh keeps it nowhere near expiry; provision-euvd.sh
+      # falls back to the deployed copy if one ever does lapse.
+      - name: Publish the snapshot for the deploy to read
+        if: steps.probe.outputs.changed == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: euvd-snapshot
+          path: ${{ runner.temp }}/euvd
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: Dispatch the Pages deploy
         if: steps.probe.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  actions: read # read the euvd-snapshot artifact the refresh workflow published
 
 # Allow one concurrent deployment; don't cancel an in-progress publish.
 concurrency:
@@ -44,8 +45,20 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-${{ github.job }}-
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      # SKIP_EUVD keeps the deploy off ENISA entirely: it throttles bursts, and a
+      # deploy that re-crawled the API on every push could be taken down by a 429
+      # it had no business making. The snapshot arrives below instead, from what
+      # the refresh workflow published.
       - name: Build the browser demo into docs/browser
+        env:
+          SKIP_EUVD: "1"
         run: ./scripts/build-demo.sh
+      # After the build: build-demo.sh clears docs/browser as it starts, so the
+      # snapshot has to land once the tree it lives in exists.
+      - name: Provision the EUVD snapshot from the refresh workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/provision-euvd.sh docs/browser/euvd
       - uses: actions/configure-pages@v6
         with:
           enablement: true

--- a/scripts/fetch-euvd.sh
+++ b/scripts/fetch-euvd.sh
@@ -10,8 +10,15 @@
 # static shards the browser loads instead.
 #
 #   scripts/fetch-euvd.sh [OUT_DIR]
+#   scripts/fetch-euvd.sh --list-pairs
 #
 # OUT_DIR defaults to docs/browser/euvd. Requires curl, jq, sha256sum.
+#
+# This is the only thing in CI that talks to EUVD, and it runs from one
+# scheduled workflow (.github/workflows/euvd-refresh.yml). Everything else —
+# the Pages deploy included — reads the snapshot that workflow publishes; see
+# scripts/provision-euvd.sh. `--list-pairs` exists so the workflow reads the
+# runtime list from here instead of keeping its own copy in step.
 #
 # Data: ENISA EUVD, CC BY 4.0 — see the NOTICE written alongside the shards.
 set -euo pipefail
@@ -32,6 +39,7 @@ pairs=(
   "Electron|Electron|electron"
   "Tauri|Tauri|tauri"
   "Node.js|Node.js|node"
+  "Deno|Deno|deno"
   "Google|Chrome|chrome"
   "Google|Flutter|flutter"
   "Qt|Qt|qt"
@@ -40,16 +48,31 @@ pairs=(
   "Oracle|JDK|jdk"
 )
 
-rm -rf "$out"
-mkdir -p "$out"
+if [ "${1:-}" = "--list-pairs" ]; then
+  printf '%s\n' "${pairs[@]}"
+  exit 0
+fi
+
+# Build into a staging directory beside the target and swap it in only once
+# every shard and the manifest are written: a 429 partway through must leave the
+# previous snapshot intact rather than delete it and stop. Staging next to the
+# target keeps the swap on one filesystem.
+parent="$(dirname "$out")"
+mkdir -p "$parent"
+stage="$(mktemp -d "$parent/.euvd-stage.XXXXXX")"
+trap 'rm -rf "$stage"' EXIT
 
 urlenc() { jq -rn --arg s "$1" '$s|@uri'; }
 
 # One GET against the API. EUVD throttles request bursts — a Chrome-sized
 # product paginates ~34 back-to-back requests, enough for a 429 from a shared
-# CI runner IP — so let curl retry transient failures (429 and 5xx qualify)
-# with exponential backoff, honouring a Retry-After header when one is sent.
-euvd_get() { curl -fsS --retry 5 "$1"; }
+# CI runner IP. `--retry-all-errors` is what makes the retry cover a 429 that
+# arrives without a Retry-After header, and the delay floor keeps the backoff
+# from restarting the burst a second later; the cap bounds a run against a
+# genuinely unavailable API.
+euvd_get() {
+  curl -fsS --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 120 "$1"
+}
 
 shards_json="{}"
 
@@ -94,10 +117,10 @@ for entry in "${pairs[@]}"; do
   # keeps correctness independent of GitHub Pages' fixed Cache-Control.
   hash="$(sha256sum "$tmp/shard.json" | cut -d' ' -f1)"
   file="$slug-${hash:0:16}.json"
-  mv "$tmp/shard.json" "$out/$file"
+  mv "$tmp/shard.json" "$stage/$file"
   rm -rf "$tmp"
-  count="$(jq 'length' <"$out/$file")"
-  bytes="$(wc -c <"$out/$file" | tr -d ' ')"
+  count="$(jq 'length' <"$stage/$file")"
+  bytes="$(wc -c <"$stage/$file" | tr -d ' ')"
   echo "euvd: $vendor/$product → $file ($count advisories, $bytes bytes)"
 
   shards_json="$(jq -c \
@@ -140,9 +163,9 @@ jq -n \
     },
     shards: $shards
   }' \
-  >"$out/index.json"
+  >"$stage/index.json"
 
-cat >"$out/NOTICE" <<'NOTICE'
+cat >"$stage/NOTICE" <<'NOTICE'
 Vulnerability data in this directory © European Union Agency for Cybersecurity
 (ENISA), European Vulnerability Database (EUVD), https://euvd.enisa.europa.eu/
 
@@ -152,5 +175,10 @@ Licensed under the Creative Commons Attribution 4.0 International licence
 Modified: reduced to the runtimes Achilles detects and re-serialised to a
 compact per-runtime subset. Not endorsed by ENISA.
 NOTICE
+
+# Everything fetched and written: swap the complete snapshot into place. Up to
+# here a failure has left the previous one untouched.
+rm -rf "$out"
+mv "$stage" "$out"
 
 echo "euvd snapshot → $out (version ${version:0:12}…)"

--- a/scripts/provision-euvd.sh
+++ b/scripts/provision-euvd.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Fill a directory with the EUVD snapshot, without contacting EUVD.
+#
+#   scripts/provision-euvd.sh [OUT_DIR]
+#
+# OUT_DIR defaults to docs/browser/euvd. Requires curl and jq; the artifact path
+# also needs `gh` authenticated with `actions: read`.
+#
+# ENISA throttles bursts, and a Pages deploy used to re-crawl the whole API on
+# every push — a README typo paid ~60 requests and could take the deploy down
+# with a 429. Only .github/workflows/euvd-refresh.yml fetches now; this fills the
+# build from what that workflow published:
+#
+#   1. the euvd-snapshot artifact of the newest successful euvd-refresh run
+#   2. else the previous deployment, served by GitHub Pages
+#   3. else nothing, with a warning
+#
+# There is deliberately no fallback to EUVD. An empty directory is a correct
+# outcome: with no manifest the browser reports EUVD as not-yet-downloaded,
+# whereas a partial snapshot would read as a clean bill of health.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+out="${1:-$root/docs/browser/euvd}"
+repo="${GITHUB_REPOSITORY:-}"
+
+# Same staging discipline as the fetcher: nothing replaces a populated target
+# until a whole snapshot is in hand.
+parent="$(dirname "$out")"
+mkdir -p "$parent"
+stage="$(mktemp -d "$parent/.euvd-provision.XXXXXX")"
+trap 'rm -rf "$stage"' EXIT
+
+# A snapshot is the manifest plus every shard it names. Anything less is refused,
+# so a truncated download can never be swapped in.
+complete() { # <dir>
+  local dir="$1" file
+  [ -s "$dir/index.json" ] || return 1
+  jq -e '.shards | length > 0' "$dir/index.json" >/dev/null 2>&1 || return 1
+  while read -r file; do
+    [ -s "$dir/$file" ] || return 1
+  done < <(jq -r '.shards[].file' "$dir/index.json")
+}
+
+from_artifact() {
+  [ -n "$repo" ] || return 1
+  command -v gh >/dev/null 2>&1 || return 1
+  local run
+  run="$(gh run list --repo "$repo" --workflow euvd-refresh.yml \
+    --status success --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)"
+  [ -n "$run" ] || return 1
+  gh run download "$run" --repo "$repo" --name euvd-snapshot --dir "$stage" >/dev/null 2>&1 || return 1
+  complete "$stage"
+}
+
+from_pages() {
+  [ -n "$repo" ] || return 1
+  local base="https://${repo%%/*}.github.io/${repo##*/}/browser/euvd" file
+  curl -fsS --retry 3 --retry-all-errors -o "$stage/index.json" "$base/index.json" 2>/dev/null || return 1
+  jq -e '.shards | length > 0' "$stage/index.json" >/dev/null 2>&1 || return 1
+  while read -r file; do
+    curl -fsS --retry 3 --retry-all-errors -o "$stage/$file" "$base/$file" 2>/dev/null || return 1
+  done < <(jq -r '.shards[].file' "$stage/index.json")
+  curl -fsS -o "$stage/NOTICE" "$base/NOTICE" 2>/dev/null || true
+  complete "$stage"
+}
+
+describe() { jq -r '"\(.shards | length) shard(s), version \(.version[0:12])…"' "$stage/index.json"; }
+
+if from_artifact; then
+  echo "euvd: provisioned from the euvd-refresh artifact ($(describe))"
+elif rm -rf "$stage" && mkdir -p "$stage" && from_pages; then
+  echo "euvd: provisioned from the deployed site ($(describe))"
+else
+  echo "::warning::no EUVD snapshot available (no artifact, no deployed copy) — building without one; the browser will report EUVD as not yet downloaded"
+  mkdir -p "$out"
+  exit 0
+fi
+
+rm -rf "$out"
+mv "$stage" "$out"


### PR DESCRIPTION
ENISA throttles bursts, and the Pages deploy re-crawled the whole API on every push: a README typo paid ~60 paginated requests and a 429 took the deploy down with it, the demo already built.

The refresh workflow is now the only thing that contacts EUVD. It publishes the snapshot as the euvd-snapshot artifact, and scripts/provision-euvd.sh fills the deploy from that artifact, falling back to the previous deployment served by Pages, and finally to nothing with a warning — never to EUVD. An empty snapshot is a correct outcome there: with no manifest the browser reports EUVD as not yet downloaded, while a partial one would read as a clean bill of health.

The probe stays as the gate, so a full crawl happens only when a per-runtime total actually moved, and the schedule moves to six-hourly with a stagger derived from the repository name — cron fires every fork at the same instant, and they share ENISA as a target.

fetch-euvd.sh builds into a staging directory and swaps it in only once the manifest is written; until now it deleted the previous snapshot before the first request, so being throttled partway through left nothing behind. Its retry covers a 429 that arrives without a Retry-After header. Deno joins the runtime list — crates/cve dispatches it, no shard answered, and the browser showed a Deno bundle an empty EUVD bucket that reads as clean. The workflow now reads that list from the script instead of keeping a second copy, which is how the two drifted apart.