### PR TITLE
fix(cve): report the fix for the line the version is actually on

### DIFF
--- a/crates/cve/src/advisory.rs
+++ b/crates/cve/src/advisory.rs
@@ -61,8 +61,12 @@ pub struct Advisory {
     pub source: Source,
     pub summary: String,
     pub severity: Option<Severity>,
-    /// First patched version we could infer. Best-effort: multi-range CVEs
-    /// may report the fix from the first applicable range.
+    /// The release that fixes the version that was queried.
+    ///
+    /// An advisory often covers several release lines at once, each with its
+    /// own fix, so this is chosen against the version asked about rather than
+    /// taken from whichever range the record happens to list first. Falls back
+    /// to the first fix in the record when the version is unknown.
     pub fixed_in: Option<String>,
     /// Other identifiers the advisory is known by.
     pub aliases: Vec<String>,

--- a/crates/cve/src/sources/osv.rs
+++ b/crates/cve/src/sources/osv.rs
@@ -110,7 +110,11 @@ pub async fn lookup(
     }
     let parsed: QueryResponse = serde_json::from_str(&text)
         .map_err(|e| Error::BadPayload(format!("osv {ecosystem}: {e}")))?;
-    let advisories: Vec<Advisory> = parsed.vulns.into_iter().map(to_advisory).collect();
+    let advisories: Vec<Advisory> = parsed
+        .vulns
+        .into_iter()
+        .map(|v| to_advisory(v, Some(version)))
+        .collect();
 
     cache::put(&cache_key, &advisories);
     Ok(advisories)
@@ -172,10 +176,11 @@ pub async fn batch_npm(
         // Hydrate each vuln id that fired against a dep we care about.
         for (chunk_pos, result) in batch.results.into_iter().enumerate() {
             let out_index = chunk[chunk_pos];
+            let version = out[out_index].package.version.clone();
             let mut advisories = Vec::with_capacity(result.vulns.len());
             for vref in result.vulns {
                 // Re-hydrate via GET /v1/vulns/{id} for the full record.
-                match hydrate(http, &vref.id).await {
+                match hydrate(http, &vref.id, Some(&version)).await {
                     Ok(advisory) => advisories.push(advisory),
                     Err(_) => {
                         // Skip individual hydration failures — they shouldn't
@@ -193,7 +198,10 @@ pub async fn batch_npm(
 }
 
 /// Fetch the full OSV record for a specific id.
-async fn hydrate(http: &Client, id: &str) -> Result<Advisory, Error> {
+///
+/// `version` is the release the caller is asking about, so a multi-range
+/// advisory can report the fix for the line that release is actually on.
+async fn hydrate(http: &Client, id: &str, version: Option<&str>) -> Result<Advisory, Error> {
     let url = format!("https://api.osv.dev/v1/vulns/{id}");
     let res = http.get(&url).send().await?;
     let status = res.status();
@@ -208,22 +216,80 @@ async fn hydrate(http: &Client, id: &str) -> Result<Advisory, Error> {
     }
     let vuln: Vulnerability = serde_json::from_str(&text)
         .map_err(|e| Error::BadPayload(format!("osv hydrate {id}: {e}")))?;
-    Ok(to_advisory(vuln))
+    Ok(to_advisory(vuln, version))
 }
 
-fn to_advisory(v: Vulnerability) -> Advisory {
+/// The release that fixes `version`, out of an advisory that may describe
+/// several affected ranges.
+///
+/// An advisory routinely covers more than one release line — `rand`'s
+/// unsoundness is fixed in 0.8.6, 0.9.3 and 0.10.1 depending on which line you
+/// are on. Taking the first `fixed` event in the record answers a question
+/// nobody asked: for 0.7.3 it reports 0.9.3, a version that requires crossing
+/// two majors, when 0.8.6 is the actual fix.
+///
+/// So walk the events of each range in order, tracking the interval an
+/// `introduced` opens and a `fixed` closes, and return the fix belonging to
+/// the interval that contains `version`. Falls back to the first `fixed` found
+/// when the version is unknown or unparseable, which is what the caller used
+/// to get for every case.
+fn fixed_for(affected: &[Affected], version: Option<&str>) -> Option<String> {
+    let parsed = version.and_then(|v| semver::Version::parse(v).ok());
+
+    let has_ranges = affected.iter().any(|a| !a.ranges.is_empty());
+    if let (Some(current), true) = (parsed, has_ranges) {
+        for range in affected.iter().flat_map(|a| a.ranges.iter()) {
+            let mut introduced: Option<semver::Version> = None;
+            for event in &range.events {
+                if let Some(at) = event.get("introduced").and_then(|v| v.as_str()) {
+                    // OSV writes "0" for "affected from the beginning".
+                    introduced = if at == "0" {
+                        Some(semver::Version::new(0, 0, 0))
+                    } else {
+                        semver::Version::parse(at).ok()
+                    };
+                    continue;
+                }
+                let Some(at) = event.get("fixed").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                let Ok(fixed) = semver::Version::parse(at) else {
+                    continue;
+                };
+                // `map_or` rather than `is_none_or`: this crate's MSRV is
+                // 1.80 and the latter is only stable from 1.82.
+                #[allow(clippy::unnecessary_map_or)]
+                let opened = introduced.as_ref().map_or(true, |i| current >= *i);
+                if opened && current < fixed {
+                    return Some(at.to_owned());
+                }
+                introduced = None;
+            }
+        }
+        // The version is known and every range was checked: it sits outside
+        // all of them, so no fix here applies to it. Falling through would
+        // hand back some other line's fix and invent an upgrade nobody needs.
+        return None;
+    }
+
+    // No usable version, or an advisory that describes affected versions some
+    // other way than ranges. The first fix in the record is the best available
+    // answer, and what every caller used to get.
+    affected
+        .iter()
+        .flat_map(|a| a.ranges.iter())
+        .flat_map(|r| r.events.iter())
+        .find_map(|e| e.get("fixed").and_then(|v| v.as_str()).map(str::to_owned))
+}
+
+fn to_advisory(v: Vulnerability, version: Option<&str>) -> Advisory {
     use std::str::FromStr;
     let severity = v
         .database_specific
         .severity
         .as_deref()
         .and_then(|s| Severity::from_str(s).ok());
-    let fixed_in = v
-        .affected
-        .iter()
-        .flat_map(|a| a.ranges.iter())
-        .flat_map(|r| r.events.iter())
-        .find_map(|e| e.get("fixed").and_then(|v| v.as_str()).map(str::to_owned));
+    let fixed_in = fixed_for(&v.affected, version);
     Advisory {
         id: v.id,
         source: Source::Osv,
@@ -238,4 +304,76 @@ fn to_advisory(v: Vulnerability) -> Advisory {
 
 fn cache_key_for(dep: &NpmPackage) -> String {
     format!("osv-npm-{}-{}", dep.name.replace('/', "_"), dep.version)
+}
+
+#[cfg(test)]
+mod fixed_for_tests {
+    use super::*;
+
+    /// The real record for RUSTSEC-2026-0097 / GHSA-cq8v-f236-94qc: one
+    /// unsoundness in `rand`, fixed separately on three release lines, and
+    /// listed with the 0.9 line first.
+    fn rand_advisory() -> Vec<Affected> {
+        serde_json::from_value(serde_json::json!([{
+            "ranges": [{
+                "events": [
+                    {"introduced": "0.9.0"}, {"fixed": "0.9.3"},
+                    {"introduced": "0.10.0"}, {"fixed": "0.10.1"},
+                    {"introduced": "0.7.0"}, {"fixed": "0.8.6"}
+                ]
+            }]
+        }]))
+        .expect("fixture parses")
+    }
+
+    #[test]
+    fn the_fix_belongs_to_the_line_the_version_is_on() {
+        let affected = rand_advisory();
+        // 0.7.3 is fixed by 0.8.6 — not by 0.9.3, which is listed first and is
+        // two majors away.
+        assert_eq!(
+            fixed_for(&affected, Some("0.7.3")).as_deref(),
+            Some("0.8.6")
+        );
+        assert_eq!(
+            fixed_for(&affected, Some("0.9.1")).as_deref(),
+            Some("0.9.3")
+        );
+        assert_eq!(
+            fixed_for(&affected, Some("0.10.0")).as_deref(),
+            Some("0.10.1")
+        );
+    }
+
+    #[test]
+    fn a_version_past_every_fix_matches_no_range() {
+        // 0.8.7 is past 0.8.6 and below 0.9.0: not affected at all. Nothing
+        // should claim it needs the 0.9 or 0.10 fix.
+        let affected = rand_advisory();
+        assert_eq!(fixed_for(&affected, Some("0.8.7")), None);
+    }
+
+    #[test]
+    fn an_unknown_version_falls_back_to_the_first_fix() {
+        // The batch path cannot always name a version; the old behaviour is
+        // still the best available answer there.
+        let affected = rand_advisory();
+        assert_eq!(fixed_for(&affected, None).as_deref(), Some("0.9.3"));
+        assert_eq!(
+            fixed_for(&affected, Some("not-a-version")).as_deref(),
+            Some("0.9.3")
+        );
+    }
+
+    #[test]
+    fn introduced_zero_means_from_the_beginning() {
+        let affected: Vec<Affected> = serde_json::from_value(serde_json::json!([{
+            "ranges": [{"events": [{"introduced": "0"}, {"fixed": "1.2.3"}]}]
+        }]))
+        .expect("fixture parses");
+        assert_eq!(
+            fixed_for(&affected, Some("0.0.1")).as_deref(),
+            Some("1.2.3")
+        );
+    }
 }


### PR DESCRIPTION
An advisory usually covers several release lines, each patched separately. `fixed_in` took the first `fixed` event in the record, which answers a question nobody asked: RUSTSEC-2026-0097 lists the 0.9 line first, so a project on `rand 0.7.3` was told to go to 0.9.3 — across two majors — when 0.8.6 is the fix for the line it is on. Consumers then plan an upgrade that is larger than necessary and, for a transitive dependency, usually impossible.

The events of a range are now walked in order, tracking the interval an `introduced` opens and a `fixed` closes, and the fix returned is the one whose interval contains the queried version. A version that matches no range returns nothing rather than some other line's fix — 0.8.7 is past 0.8.6 and below 0.9.0, so it is not affected at all and has nothing to upgrade to.

Where no version is available — the batch path could not always name one, and it now does — or an advisory describes its affected set some way other than ranges, the first fix in the record is still the answer, which is what every caller used to get.