### PR TITLE
chore(renovate): adopt shared org preset

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,7 @@
+// Per-repo Renovate config. Everything else comes from the shared org preset;
+// keys set here override it.
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  schedule: ["before 6am on the first day of the month"],
+  extends: ["github>crabnebula-dev/dependency-tracking//config/renovate-preset.json5"],
+}


### PR DESCRIPTION
Adopts the shared org Renovate preset from crabnebula-dev/dependency-tracking: grouped non-breaking updates, framework majors grouped, security PRs on any schedule, `dependencies` label. Repo-level keys override the preset; the monthly schedule here is a starting point.

ref https://github.com/crabnebula-dev/dependency-tracking/blob/main/config/renovate-preset.json5